### PR TITLE
Include colored gem which is required for the scafolding in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ of Skygear iOS app for you, including:
 ```bash
 sudo gem install cocoapods
 
+sudo gem install colored
+
 pod repo update
 
 pod lib create --silent --template-url=https://github.com/SkygearIO/skygear-Scaffolding-iOS.git "YourProjectName"


### PR DESCRIPTION
Not sure if I did something wrong instead. I tried to use it on my newly upgrade High Sierra but it required colored too