### PR TITLE
Use colored2 dep instead of color

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ of Skygear iOS app for you, including:
 ## How to use
 
 ```bash
-sudo gem install colored cocoapods
+sudo gem install cocoapods
 
 pod repo update
 

--- a/setup/TemplateConfigurator.rb
+++ b/setup/TemplateConfigurator.rb
@@ -1,5 +1,5 @@
 require 'fileutils'
-require 'colored'
+require 'colored2'
 
 module Pod
   class TemplateConfigurator
@@ -38,7 +38,7 @@ module Pod
       print_info = Proc.new {
 
         possible_answers_string = possible_answers.each_with_index do |answer, i|
-           _answer = (i == 0) ? answer.underline : answer
+           _answer = (i == 0) ? answer.underlined : answer
            print " " + _answer
            print(" /") if i != possible_answers.length-1
         end


### PR DESCRIPTION
CocoaPods now ship with colored2 instead of colored. This commit update
the TemplateConfigurator to use colored2 instead so that user does not
need to install colored explicitly.

refs CocoaPods/CocoaPods#6652